### PR TITLE
Disable autoplay to improve user experience

### DIFF
--- a/index.html
+++ b/index.html
@@ -202,7 +202,7 @@
     <!-- <td>Video Id</td> -->
   <table class="styled-table"><tr><td>Input Video</td><td>Input Query</td><td>Duration</td><td>Ground Truth</td><td>Prediction</td><td>IOU</td><td>Result Clips</td></tr>
     <tr>
-      <td><iframe width="200" height="300" src="https://www.youtube.com/embed/JtoXTI2uouA?si=Cl15eBvgZhFC-xOb" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe></td>
+      <td><iframe width="200" height="300" src="https://www.youtube.com/embed/JtoXTI2uouA?si=Cl15eBvgZhFC-xOb" title="YouTube video player" frameborder="0" allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe></td>
       <td>basketball statue</td><td>00:00:46</td><td>00:00:13-00:00:30</td><td>00:00:13-00:00:31</td><td>0.94</td>
       <td><iframe src="static/videos/JtoXTI2uouA_13_30_256.mp4" width="200" height="300"></iframe></td>
     </tr>
@@ -221,7 +221,7 @@
       <td><iframe src="static/videos/cCFE8uIHvnQ_24_32_256.mp4" width="200"></iframe></td>
     </tr>
     <tr>
-      <td><iframe width="200" src="https://www.youtube.com/embed/AYM65NL5714?si=yfbUPafw0rDdX8L9" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe></td>
+      <td><iframe width="200" src="https://www.youtube.com/embed/AYM65NL5714?si=yfbUPafw0rDdX8L9" title="YouTube video player" frameborder="0" allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe></td>
       <td>Euripides, has most surviving work like 'Medea' and 'The Bacchae', debut in 455 BC. He is a corner stone of greek education in the Hellenistic period.</td><td>00:05:10</td><td>00:04:22-00:04:41</td><td>00:04:20-00:04:35</td><td>0.62</td>
       <td><iframe src="static/videos/AYM65NL5714_260_274_256.mp4" width="200"></iframe></td>
     </tr>
@@ -247,12 +247,12 @@
       <!-- <td><iframe src="static/videos/QE-a2L1N59Q_403_751_256.mp4" width="200"></iframe></td> -->
     <!-- </tr> -->
     <tr>
-      <td><iframe width="200" src="https://www.youtube.com/embed/PxHpInG6iFo?si=_Qk1_v7vjgWVsU7V" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe></td>
+      <td><iframe width="200" src="https://www.youtube.com/embed/PxHpInG6iFo?si=_Qk1_v7vjgWVsU7V" title="YouTube video player" frameborder="0" allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe></td>
       <td>FTC resources</td><td>00:59:35</td><td>00:43:41-00:44:17</td><td>00:43:31-00:44:15</td><td>0.74</td>
       <td><iframe src="static/videos/PxHpInG6iFo_2611_2654_256.mp4" width="200"></iframe></td>
     </tr>
     <tr>
-      <td><iframe width="200" src="https://www.youtube.com/embed/wDKzPVJ0EjI?si=XLZDokOuh-98-GYl" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe></td>
+      <td><iframe width="200" src="https://www.youtube.com/embed/wDKzPVJ0EjI?si=XLZDokOuh-98-GYl" title="YouTube video player" frameborder="0" allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe></td>
       <td>North Devon Marine Pioneer</td><td>01:24:45</td><td>00:00:00-00:02:31, 00:03:58-00:06:20, 00:13:32-00:16:01, 00:16:57-00:17:00, 00:47:21-01:03:10</td><td>00:00:00-00:02:33, 00:46:56-01:03:08</td><td>0.77</td>
       <td><iframe src="static/videos/wDKzPVJ0EjI_0_152_256.mp4" width="200"></iframe>
         <iframe src="static/videos/wDKzPVJ0EjI_2816_3787_256.mp4" width="200"></iframe></td>

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -9,7 +9,7 @@ $(document).ready(function() {
 			slidesToShow: 1,
 			loop: true,
 			infinite: true,
-			autoplay: true,
+			autoplay: false,
 			autoplaySpeed: 5000,
     }
 


### PR DESCRIPTION
## Summary
Disables audio/video autoplay on page load to provide better user experience and comply with modern web standards.

## Changes
- Set `autoplay: false` in `static/js/index.js`
- Removed autoplay attributes from HTML elements


## Files Modified
- `static/js/index.js`
- `index.html`

Closes #1 